### PR TITLE
Add ways to run Docker commands instead of skpr directly.

### DIFF
--- a/src/commands/backup.yml
+++ b/src/commands/backup.yml
@@ -2,6 +2,10 @@ description: >
   Create a backup of an environment.
 
 parameters:
+  docker_image_tag:
+    default: "skpr/cli:latest"
+    description: "The Skpr CLI version tag"
+    type: string
   target:
     type: string
     description: "The target environment to create a backup from"
@@ -9,11 +13,16 @@ parameters:
     type: string
     description: "How long to wait for the build to complete"
     default: "1h"
+  title:
+    type: string
+    description: "Tile of the job to appear in CircleCI's interface."
+    default: "Skpr Backup"
 
 steps:
   - run:
       environment:
+        SKPR_CLI_DOCKER_IMAGE: <<parameters.docker_image_tag>>
         SKPR_TARGET: <<parameters.target>>
-      name: Skpr Backup
+      name: <<parameters.title>>
       command: <<include(scripts/backup.sh)>>
       no_output_timeout: <<parameters.timeout>>

--- a/src/commands/backup.yml
+++ b/src/commands/backup.yml
@@ -2,7 +2,7 @@ description: >
   Create a backup of an environment.
 
 parameters:
-  docker_image_tag:
+  docker_image:
     default: "skpr/cli:latest"
     description: "The Skpr CLI version tag"
     type: string
@@ -21,7 +21,7 @@ parameters:
 steps:
   - run:
       environment:
-        SKPR_CLI_DOCKER_IMAGE: <<parameters.docker_image_tag>>
+        SKPR_CLI_DOCKER_IMAGE: <<parameters.docker_image>>
         SKPR_TARGET: <<parameters.target>>
       name: <<parameters.title>>
       command: <<include(scripts/backup.sh)>>

--- a/src/commands/deploy.yml
+++ b/src/commands/deploy.yml
@@ -2,7 +2,7 @@ description: >
   Deploys to Skpr.
 
 parameters:
-  docker_image_tag:
+  docker_image:
     default: "skpr/cli:latest"
     description: "The Skpr CLI version tag"
     type: string
@@ -22,7 +22,7 @@ parameters:
 steps:
   - run:
       environment:
-        SKPR_CLI_DOCKER_IMAGE: <<parameters.docker_image_tag>>
+        SKPR_CLI_DOCKER_IMAGE: <<parameters.docker_image>>
         SKPR_VERSION: <<parameters.version>>
         SKPR_ENV: <<parameters.env>>
       name: <<parameters.title>>

--- a/src/commands/deploy.yml
+++ b/src/commands/deploy.yml
@@ -2,19 +2,28 @@ description: >
   Deploys to Skpr.
 
 parameters:
-  version:
+  docker_image_tag:
+    default: "skpr/cli:latest"
+    description: "The Skpr CLI version tag"
     type: string
-    default: ""
-    description: "The app version"
   env:
     type: string
     default: ""
     description: "The app environment"
+  title:
+    type: string
+    description: "Tile of the job to appear in CircleCI's interface."
+    default: "Skpr Deploy"
+  version:
+    type: string
+    default: ""
+    description: "The app version"
 
 steps:
   - run:
       environment:
+        SKPR_CLI_DOCKER_IMAGE: <<parameters.docker_image_tag>>
         SKPR_VERSION: <<parameters.version>>
         SKPR_ENV: <<parameters.env>>
-      name: Skpr Deploy
+      name: <<parameters.title>>
       command: <<include(scripts/deploy.sh)>>

--- a/src/commands/exec.yml
+++ b/src/commands/exec.yml
@@ -1,32 +1,34 @@
 description: >
-  Restores the latest backup available of an environment to Skpr.
+  Execs a command via the Skpr CLI.
 
 parameters:
   docker_image_tag:
     default: "skpr/cli:latest"
     description: "The Skpr CLI version tag"
     type: string
-  source:
+  env:
     type: string
-    description: "The source environment to grab the backup from"
-  target:
+    default: ""
+    description: "The app environment"
+  command:
     type: string
-    description: "The target environment to restore the backup to"
+    default: ""
+    description: "The app command"
   timeout:
     type: string
-    description: "How long to wait for the build to complete"
-    default: "1h"
+    default: "10m"
+    description: "How long to wait for the step to complete"
   title:
     type: string
     description: "Tile of the job to appear in CircleCI's interface."
-    default: "Skpr Backup"
+    default: "Skpr Exec"
 
 steps:
   - run:
       environment:
         SKPR_CLI_DOCKER_IMAGE: <<parameters.docker_image_tag>>
-        SKPR_SOURCE: <<parameters.source>>
-        SKPR_TARGET: <<parameters.target>>
+        SKPR_CMD: <<parameters.command>>
+        SKPR_ENV: <<parameters.env>>
       name: <<parameters.title>>
-      command: <<include(scripts/restore.sh)>>
+      command: <<include(scripts/exec.sh)>>
       no_output_timeout: <<parameters.timeout>>

--- a/src/commands/exec.yml
+++ b/src/commands/exec.yml
@@ -2,7 +2,7 @@ description: >
   Execs a command via the Skpr CLI.
 
 parameters:
-  docker_image_tag:
+  docker_image:
     default: "skpr/cli:latest"
     description: "The Skpr CLI version tag"
     type: string
@@ -26,7 +26,7 @@ parameters:
 steps:
   - run:
       environment:
-        SKPR_CLI_DOCKER_IMAGE: <<parameters.docker_image_tag>>
+        SKPR_CLI_DOCKER_IMAGE: <<parameters.docker_image>>
         SKPR_CMD: <<parameters.command>>
         SKPR_ENV: <<parameters.env>>
       name: <<parameters.title>>

--- a/src/commands/info.yml
+++ b/src/commands/info.yml
@@ -2,7 +2,7 @@ description: >
   Gets Skpr environment information.
 
 parameters:
-  docker_image_tag:
+  docker_image:
     default: "skpr/cli:latest"
     description: "The Skpr CLI version tag"
     type: string
@@ -14,7 +14,7 @@ parameters:
 steps:
   - run:
       environment:
-        SKPR_CLI_DOCKER_IMAGE: <<parameters.docker_image_tag>>
+        SKPR_CLI_DOCKER_IMAGE: <<parameters.docker_image>>
         SKPR_ENV: <<parameters.env>>
       name: Skpr Info
       command: <<include(scripts/info.sh)>>

--- a/src/commands/mysql-image-pull.yml
+++ b/src/commands/mysql-image-pull.yml
@@ -1,0 +1,24 @@
+description: >
+  Pull a MySQL Database Image
+
+parameters:
+  docker_image_tag:
+    default: "skpr/cli:latest"
+    description: "The Skpr CLI version tag"
+    type: string
+  environment:
+    description: "Environment to pull the MySQL image from"
+    type: string
+  timeout:
+    default: "1h"
+    description: "How long to wait for the step to complete"
+    type: string
+
+steps:
+  - run:
+      environment:
+        SKPR_CLI_DOCKER_IMAGE: <<parameters.docker_image_tag>>
+        SKPR_ENVIRONMENT: <<parameters.environment>>
+      name: Skpr MySQL Image Pull
+      command: <<include(scripts/mysql-image-pull.sh)>>
+      no_output_timeout: <<parameters.timeout>>

--- a/src/commands/mysql-image-pull.yml
+++ b/src/commands/mysql-image-pull.yml
@@ -2,7 +2,7 @@ description: >
   Pull a MySQL Database Image
 
 parameters:
-  docker_image_tag:
+  docker_image:
     default: "skpr/cli:latest"
     description: "The Skpr CLI version tag"
     type: string
@@ -17,8 +17,8 @@ parameters:
 steps:
   - run:
       environment:
-        SKPR_CLI_DOCKER_IMAGE: <<parameters.docker_image_tag>>
-        SKPR_ENVIRONMENT: <<parameters.env>>
+        SKPR_CLI_DOCKER_IMAGE: <<parameters.docker_image>>
+        SKPR_ENV: <<parameters.env>>
       name: Skpr MySQL Image Pull
       command: <<include(scripts/mysql-image-pull.sh)>>
       no_output_timeout: <<parameters.timeout>>

--- a/src/commands/mysql-image-pull.yml
+++ b/src/commands/mysql-image-pull.yml
@@ -6,7 +6,7 @@ parameters:
     default: "skpr/cli:latest"
     description: "The Skpr CLI version tag"
     type: string
-  environment:
+  env:
     description: "Environment to pull the MySQL image from"
     type: string
   timeout:
@@ -18,7 +18,7 @@ steps:
   - run:
       environment:
         SKPR_CLI_DOCKER_IMAGE: <<parameters.docker_image_tag>>
-        SKPR_ENVIRONMENT: <<parameters.environment>>
+        SKPR_ENVIRONMENT: <<parameters.env>>
       name: Skpr MySQL Image Pull
       command: <<include(scripts/mysql-image-pull.sh)>>
       no_output_timeout: <<parameters.timeout>>

--- a/src/commands/package.yml
+++ b/src/commands/package.yml
@@ -2,6 +2,10 @@ description: >
   Packages an app for deployment.
 
 parameters:
+  docker_image_tag:
+    default: "skpr/cli:latest"
+    description: "The Skpr CLI version tag"
+    type: string
   version:
     type: string
     default: ""
@@ -10,6 +14,7 @@ parameters:
 steps:
   - run:
       environment:
+        SKPR_CLI_DOCKER_IMAGE: <<parameters.docker_image_tag>>
         PARAM_VERSION: <<parameters.version>>
       name: Skpr Package
       command: <<include(scripts/package.sh)>>

--- a/src/commands/package.yml
+++ b/src/commands/package.yml
@@ -2,7 +2,7 @@ description: >
   Packages an app for deployment.
 
 parameters:
-  docker_image_tag:
+  docker_image:
     default: "skpr/cli:latest"
     description: "The Skpr CLI version tag"
     type: string
@@ -14,7 +14,7 @@ parameters:
 steps:
   - run:
       environment:
-        SKPR_CLI_DOCKER_IMAGE: <<parameters.docker_image_tag>>
+        SKPR_CLI_DOCKER_IMAGE: <<parameters.docker_image>>
         PARAM_VERSION: <<parameters.version>>
       name: Skpr Package
       command: <<include(scripts/package.sh)>>

--- a/src/commands/purge.yml
+++ b/src/commands/purge.yml
@@ -2,7 +2,7 @@ description: >
   Creates a Skpr purge request.
 
 parameters:
-  docker_image_tag:
+  docker_image:
     default: "skpr/cli:latest"
     description: "The Skpr CLI version tag"
     type: string
@@ -21,7 +21,7 @@ parameters:
 steps:
   - run:
       environment:
-        SKPR_CLI_DOCKER_IMAGE: <<parameters.docker_image_tag>>
+        SKPR_CLI_DOCKER_IMAGE: <<parameters.docker_image>>
         SKPR_ENV: <<parameters.env>>
         SKPR_PATH: <<parameters.path>>
       name: <<parameters.title>>

--- a/src/commands/purge.yml
+++ b/src/commands/purge.yml
@@ -1,5 +1,5 @@
 description: >
-  Gets Skpr environment information.
+  Creates a Skpr purge request.
 
 parameters:
   docker_image_tag:
@@ -10,11 +10,19 @@ parameters:
     type: string
     default: ""
     description: "The app environment"
+  path:
+    type: string
+    description: "Paths to purge on the app."
+  title:
+    type: string
+    description: "Tile of the job to appear in CircleCI's interface."
+    default: "Skpr Purge"
 
 steps:
   - run:
       environment:
         SKPR_CLI_DOCKER_IMAGE: <<parameters.docker_image_tag>>
         SKPR_ENV: <<parameters.env>>
-      name: Skpr Info
-      command: <<include(scripts/info.sh)>>
+        SKPR_PATH: <<parameters.path>>
+      name: <<parameters.title>>
+      command: <<include(scripts/purge.sh)>>

--- a/src/commands/restore.yml
+++ b/src/commands/restore.yml
@@ -2,7 +2,7 @@ description: >
   Restores the latest backup available of an environment to Skpr.
 
 parameters:
-  docker_image_tag:
+  docker_image:
     default: "skpr/cli:latest"
     description: "The Skpr CLI version tag"
     type: string
@@ -24,7 +24,7 @@ parameters:
 steps:
   - run:
       environment:
-        SKPR_CLI_DOCKER_IMAGE: <<parameters.docker_image_tag>>
+        SKPR_CLI_DOCKER_IMAGE: <<parameters.docker_image>>
         SKPR_SOURCE: <<parameters.source>>
         SKPR_TARGET: <<parameters.target>>
       name: <<parameters.title>>

--- a/src/commands/restore.yml
+++ b/src/commands/restore.yml
@@ -19,7 +19,7 @@ parameters:
   title:
     type: string
     description: "Tile of the job to appear in CircleCI's interface."
-    default: "Skpr Backup"
+    default: "Skpr Restore"
 
 steps:
   - run:

--- a/src/commands/trivy_file_scan.yml
+++ b/src/commands/trivy_file_scan.yml
@@ -2,14 +2,23 @@ description: >
   Packages an app for deployment.
 
 parameters:
+  docker_image_tag:
+    default: "skpr/cli:latest"
+    description: "The Skpr CLI version tag"
+    type: string
   file:
     type: string
     default: ""
     description: "The filepath to pass onto trivy."
+  title:
+    type: string
+    description: "Tile of the job to appear in CircleCI's interface."
+    default: "Trivy: File Scan"
 
 steps:
   - run:
       environment:
+        SKPR_CLI_DOCKER_IMAGE: <<parameters.docker_image_tag>>
         PARAM_FILE: <<parameters.file>>
-      name: "Trivy: File Scan"
+      name: <<parameters.title>>
       command: <<include(scripts/trivy_file_scan.sh)>>

--- a/src/commands/trivy_file_scan.yml
+++ b/src/commands/trivy_file_scan.yml
@@ -2,7 +2,7 @@ description: >
   Packages an app for deployment.
 
 parameters:
-  docker_image_tag:
+  docker_image:
     default: "skpr/cli:latest"
     description: "The Skpr CLI version tag"
     type: string
@@ -18,7 +18,7 @@ parameters:
 steps:
   - run:
       environment:
-        SKPR_CLI_DOCKER_IMAGE: <<parameters.docker_image_tag>>
+        SKPR_CLI_DOCKER_IMAGE: <<parameters.docker_image>>
         PARAM_FILE: <<parameters.file>>
       name: <<parameters.title>>
       command: <<include(scripts/trivy_file_scan.sh)>>

--- a/src/commands/trivy_image_scan.yml
+++ b/src/commands/trivy_image_scan.yml
@@ -2,7 +2,7 @@ description: >
   Packages an app for deployment.
 
 parameters:
-  docker_image_tag:
+  docker_image:
     default: "skpr/cli:latest"
     description: "The Skpr CLI version tag"
     type: string
@@ -14,7 +14,7 @@ parameters:
 steps:
   - run:
       environment:
-        SKPR_CLI_DOCKER_IMAGE: <<parameters.docker_image_tag>>
+        SKPR_CLI_DOCKER_IMAGE: <<parameters.docker_image>>
         PARAM_TYPE: <<parameters.type>>
       name: "Trivy: Scan Image"
       command: <<include(scripts/trivy_image_scan.sh)>>

--- a/src/commands/trivy_image_scan.yml
+++ b/src/commands/trivy_image_scan.yml
@@ -2,6 +2,10 @@ description: >
   Packages an app for deployment.
 
 parameters:
+  docker_image_tag:
+    default: "skpr/cli:latest"
+    description: "The Skpr CLI version tag"
+    type: string
   type:
     type: string
     default: ""
@@ -10,6 +14,7 @@ parameters:
 steps:
   - run:
       environment:
+        SKPR_CLI_DOCKER_IMAGE: <<parameters.docker_image_tag>>
         PARAM_TYPE: <<parameters.type>>
       name: "Trivy: Scan Image"
       command: <<include(scripts/trivy_image_scan.sh)>>

--- a/src/scripts/backup.sh
+++ b/src/scripts/backup.sh
@@ -2,7 +2,6 @@
 
 backup() {
   docker run --rm \
-          -v /var/run/docker.sock:/var/run/docker.sock \
           -v "$(pwd):$(pwd)" \
           -w "$(pwd)" \
           -e SKPR_USERNAME="${SKPR_USERNAME}" \

--- a/src/scripts/deploy.sh
+++ b/src/scripts/deploy.sh
@@ -1,3 +1,5 @@
+#!/bin/env bash
+
 deploy() {
     if [ -z "${SKPR_VERSION}" ]; then
         if [ -z "${CIRCLE_TAG}" ]; then
@@ -7,17 +9,23 @@ deploy() {
           echo "Using 'CIRCLE_TAG' to determine version."
           SKPR_VERSION=${CIRCLE_TAG}
         fi
-        # shellcheck disable=SC2086
-        echo "export SKPR_VERSION=$SKPR_VERSION" >> $BASH_ENV
+        echo "export SKPR_VERSION=$SKPR_VERSION" >> "${BASH_ENV}"
     fi
     echo "Deploying version: ${SKPR_VERSION}"
-    # shellcheck disable=SC2086
-    skpr deploy ${SKPR_ENV} ${SKPR_VERSION}
+    docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v "$(pwd):$(pwd)" \
+            -w "$(pwd)" \
+            -e SKPR_USERNAME="${SKPR_USERNAME}" \
+            -e SKPR_PASSWORD="${SKPR_PASSWORD}" \
+            "${SKPR_CLI_DOCKER_IMAGE}" \
+            skpr deploy "${SKPR_ENV}" "${SKPR_VERSION}";
 }
 
 # Will not run if sourced for bats-core tests.
 # View src/tests for more information.
 ORB_TEST_ENV="bats-core"
+# shellcheck disable=SC2295
 if [ "${0#*$ORB_TEST_ENV}" == "$0" ]; then
     deploy
 fi

--- a/src/scripts/deploy.sh
+++ b/src/scripts/deploy.sh
@@ -13,7 +13,6 @@ deploy() {
     fi
     echo "Deploying version: ${SKPR_VERSION}"
     docker run --rm \
-            -v /var/run/docker.sock:/var/run/docker.sock \
             -v "$(pwd):$(pwd)" \
             -w "$(pwd)" \
             -e SKPR_USERNAME="${SKPR_USERNAME}" \

--- a/src/scripts/exec.sh
+++ b/src/scripts/exec.sh
@@ -1,6 +1,7 @@
 #!/bin/env bash
 
-backup() {
+exec() {
+  echo "Running '${SKPR_CMD}'"
   docker run --rm \
           -v /var/run/docker.sock:/var/run/docker.sock \
           -v "$(pwd):$(pwd)" \
@@ -8,7 +9,7 @@ backup() {
           -e SKPR_USERNAME="${SKPR_USERNAME}" \
           -e SKPR_PASSWORD="${SKPR_PASSWORD}" \
           "${SKPR_CLI_DOCKER_IMAGE}" \
-          skpr backup create --wait "${SKPR_TARGET}";
+          skpr exec "${SKPR_ENV}" -- "${SKPR_CMD}";
 }
 
 # Will not run if sourced for bats-core tests.
@@ -16,5 +17,5 @@ backup() {
 ORB_TEST_ENV="bats-core"
 # shellcheck disable=SC2295
 if [ "${0#*$ORB_TEST_ENV}" == "$0" ]; then
-	backup
+	exec
 fi

--- a/src/scripts/exec.sh
+++ b/src/scripts/exec.sh
@@ -3,7 +3,6 @@
 exec() {
   echo "Running '${SKPR_CMD}'"
   docker run --rm \
-          -v /var/run/docker.sock:/var/run/docker.sock \
           -v "$(pwd):$(pwd)" \
           -w "$(pwd)" \
           -e SKPR_USERNAME="${SKPR_USERNAME}" \

--- a/src/scripts/info.sh
+++ b/src/scripts/info.sh
@@ -1,15 +1,25 @@
+#!/bin/env bash
+
 info() {
-    # shellcheck disable=SC2086
     echo "Getting Skpr info for $SKPR_ENV"
-    SKPR_DOMAIN=$(skpr info $SKPR_ENV | jq -r ".Ingress.Domain")
-    SKPR_URL="https://$SKPR_DOMAIN"
+    docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v "$(pwd):$(pwd)" \
+            -w "$(pwd)" \
+            -e SKPR_USERNAME="${SKPR_USERNAME}" \
+            -e SKPR_PASSWORD="${SKPR_PASSWORD}" \
+            "${SKPR_CLI_DOCKER_IMAGE}" \
+            skpr info "${SKPR_ENV}" > info.json;
+    SKPR_DOMAIN=$(cat < info.json | jq -r ".Ingress.Domain")
+    SKPR_URL="https://${SKPR_DOMAIN}"
     echo "Skpr URL: $SKPR_URL"
-    echo "export SKPR_URL=$SKPR_URL" >> $BASH_ENV
+    echo "export SKPR_URL=$SKPR_URL" >> "${BASH_ENV}"
 }
 
 # Will not run if sourced for bats-core tests.
 # View src/tests for more information.
 ORB_TEST_ENV="bats-core"
+# shellcheck disable=SC2295
 if [ "${0#*$ORB_TEST_ENV}" == "$0" ]; then
     info
 fi

--- a/src/scripts/info.sh
+++ b/src/scripts/info.sh
@@ -3,7 +3,6 @@
 info() {
     echo "Getting Skpr info for $SKPR_ENV"
     docker run --rm \
-            -v /var/run/docker.sock:/var/run/docker.sock \
             -v "$(pwd):$(pwd)" \
             -w "$(pwd)" \
             -e SKPR_USERNAME="${SKPR_USERNAME}" \

--- a/src/scripts/mysql-image-pull.sh
+++ b/src/scripts/mysql-image-pull.sh
@@ -1,20 +1,19 @@
 #!/bin/env bash
 
-backup() {
-  docker run --rm \
+mysql_image_pull() {
+  docker run -it \
           -v /var/run/docker.sock:/var/run/docker.sock \
           -v "$(pwd):$(pwd)" \
           -w "$(pwd)" \
           -e SKPR_USERNAME="${SKPR_USERNAME}" \
           -e SKPR_PASSWORD="${SKPR_PASSWORD}" \
           "${SKPR_CLI_DOCKER_IMAGE}" \
-          skpr backup create --wait "${SKPR_TARGET}";
+          skpr mysql image pull dev
 }
 
 # Will not run if sourced for bats-core tests.
 # View src/tests for more information.
 ORB_TEST_ENV="bats-core"
-# shellcheck disable=SC2295
 if [ "${0#*$ORB_TEST_ENV}" == "$0" ]; then
-	backup
+	mysql_image_pull
 fi

--- a/src/scripts/mysql-image-pull.sh
+++ b/src/scripts/mysql-image-pull.sh
@@ -8,7 +8,7 @@ mysql_image_pull() {
           -e SKPR_USERNAME="${SKPR_USERNAME}" \
           -e SKPR_PASSWORD="${SKPR_PASSWORD}" \
           "${SKPR_CLI_DOCKER_IMAGE}" \
-          skpr mysql image pull dev
+          skpr mysql image pull "${SKPR_ENV}"
 }
 
 # Will not run if sourced for bats-core tests.

--- a/src/scripts/purge.sh
+++ b/src/scripts/purge.sh
@@ -1,6 +1,7 @@
 #!/bin/env bash
 
-backup() {
+purge() {
+  echo "Purging path '${SKPR_PATH}' on environment '${SKPR_ENV}..."
   docker run --rm \
           -v /var/run/docker.sock:/var/run/docker.sock \
           -v "$(pwd):$(pwd)" \
@@ -8,7 +9,7 @@ backup() {
           -e SKPR_USERNAME="${SKPR_USERNAME}" \
           -e SKPR_PASSWORD="${SKPR_PASSWORD}" \
           "${SKPR_CLI_DOCKER_IMAGE}" \
-          skpr backup create --wait "${SKPR_TARGET}";
+          skpr purge create "${SKPR_ENVIRONMENT}" "${SKPR_PATH}";
 }
 
 # Will not run if sourced for bats-core tests.
@@ -16,5 +17,5 @@ backup() {
 ORB_TEST_ENV="bats-core"
 # shellcheck disable=SC2295
 if [ "${0#*$ORB_TEST_ENV}" == "$0" ]; then
-	backup
+	purge
 fi

--- a/src/scripts/purge.sh
+++ b/src/scripts/purge.sh
@@ -3,7 +3,6 @@
 purge() {
   echo "Purging path '${SKPR_PATH}' on environment '${SKPR_ENV}..."
   docker run --rm \
-          -v /var/run/docker.sock:/var/run/docker.sock \
           -v "$(pwd):$(pwd)" \
           -w "$(pwd)" \
           -e SKPR_USERNAME="${SKPR_USERNAME}" \

--- a/src/scripts/restore.sh
+++ b/src/scripts/restore.sh
@@ -3,7 +3,6 @@
 restore() {
   # Get Backups
   docker run --rm \
-          -v /var/run/docker.sock:/var/run/docker.sock \
           -v "$(pwd):$(pwd)" \
           -w "$(pwd)" \
           -e SKPR_USERNAME="${SKPR_USERNAME}" \

--- a/src/scripts/trivy_file_scan.sh
+++ b/src/scripts/trivy_file_scan.sh
@@ -1,3 +1,5 @@
+#!/bin/env bash
+
 trivy_file_scan() {
 
   if [ "${PARAM_FILE}" == "" ]; then
@@ -9,13 +11,21 @@ trivy_file_scan() {
     echo "Input file does not exist at path: ${PARAM_FILE}";
   fi
 
-  trivy fs "${PARAM_FILE}";
+  docker run --rm \
+          -v /var/run/docker.sock:/var/run/docker.sock \
+          -v "$(pwd):$(pwd)" \
+          -w "$(pwd)" \
+          -e SKPR_USERNAME="${SKPR_USERNAME}" \
+          -e SKPR_PASSWORD="${SKPR_PASSWORD}" \
+          "${SKPR_CLI_DOCKER_IMAGE}" \
+          trivy fs "${PARAM_FILE}";
 
 }
 
 # Will not run if sourced for bats-core tests.
 # View src/tests for more information.
 ORB_TEST_ENV="bats-core"
+# shellcheck disable=SC2295
 if [ "${0#*$ORB_TEST_ENV}" == "$0" ]; then
     trivy_file_scan
 fi

--- a/src/scripts/trivy_file_scan.sh
+++ b/src/scripts/trivy_file_scan.sh
@@ -12,7 +12,6 @@ trivy_file_scan() {
   fi
 
   docker run --rm \
-          -v /var/run/docker.sock:/var/run/docker.sock \
           -v "$(pwd):$(pwd)" \
           -w "$(pwd)" \
           -e SKPR_USERNAME="${SKPR_USERNAME}" \


### PR DESCRIPTION
**Background**

A major change in how the orb works, so this is pitched as `v2.x`, so a branch at the existing version 1 has been created for future reference as needed.

**Purpose**

To use the orb on the machine executor in CircleCI which provides performance and resource improvements. The docker executor comes with tooling we've provided the CLI image but these are absent with the default environment. Environments that don't run immediately in a docker executor still have access to docker, so the intention is to use docker to run commands using the Skpr CLI image.

This will allow us to migrate some workloads to a machine executor whilst preserving a way for current users would not to experience issues with current pipelines which still use the  `skpr` command. This is facilitated using the `v1.x` releases in CircleCI config.

**Changes**

 - A new command for skpr/purge allowing purge requests (`skpr purge create`) to come through the orb.
 - A new command for skpr/exec allowing exec requests (`skpr exec`) to be created via the orb.
 - Updates to the all other commands to convert to using a machine executor via docker.
 - Updates to some other commands to allow a job title to be provided for extra flexibility to consumers.
 - Adjustments to some of the syntax to prevent the need to disable some shellcheck rules.
 - Some smaller changes to make command parameters consistent.